### PR TITLE
Fixes `validate` return type from boolean to void

### DIFF
--- a/main.d.ts
+++ b/main.d.ts
@@ -7,7 +7,7 @@ interface ValidatedMethod_Static {
   new(options: {
     name: string;
     mixins?: Function[];
-    validate: (args: { [key: string]: any; }) => boolean; // returned from SimpleSchemaInstance.validator() method;
+    validate: (args: { [key: string]: any; }) => void; // returned from SimpleSchemaInstance.validator() method;
     applyOptions?: {
       noRetry: boolean;
       returnStubValue: boolean;


### PR DESCRIPTION
`validate` function returning a boolean causes an runtime error in method call:
<blockquote>
Exception while invoking method 'm' Error: Returning from validate doesn't do anything; perhaps you meant to throw an error?
I20161216-20:44:53.075(8)?     at ValidatedMethod._execute (packages/mdg:validated-method/validated-method.js:89:13)
I20161216-20:44:53.076(8)?     at [object Object].ValidatedMethod.connection.methods._connection$methods.(anonymous function) (packages/mdg:validated-method/validated-method.js:54:23)
</blockquote>
Changed return type to `void`.